### PR TITLE
Update RealexClient.cs

### DIFF
--- a/rxp-remote-dotnet/RealexClient.cs
+++ b/rxp-remote-dotnet/RealexClient.cs
@@ -29,6 +29,9 @@ namespace RealexPayments.Remote.SDK {
             LOGGER.Debug("Marshalling request object to XML.");
             string xmlRequest = request.ToXml();
 
+            //TLS 1.1 and below are no longer supported so specify TLS 1.2 as the default
+            ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12 | SecurityProtocolType.Tls11 | SecurityProtocolType.Tls;
+            
             //send request to Realex.
             string xmlResult = HttpUtils.SendMessage(xmlRequest, HttpClient, HttpConfiguration);
 


### PR DESCRIPTION
TLS 1.1 and below are no longer supported by Realex so specify TLS 1.2 as the default. 

.NET 4.6+ supports TLS 1.2 by default already, but some users may need to use a lower version of .NET.